### PR TITLE
display help when no argv + show opn module version + add aliases

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,8 +2,13 @@
 'use strict';
 var meow = require('meow');
 var opn = require('opn');
+var path = require('path');
+var pkg = require(path.join(__dirname, 'node_modules', 'opn', 'package.json'));
 
 var cli = meow({
+	pkg: {
+		version:pkg.version
+	},
 	help: [
 		'Usage',
 		'  $ opn <file|url> [--no-wait] [-- <app> [args]]',
@@ -17,7 +22,15 @@ var cli = meow({
 		'  $ opn http://sindresorhus.com -- \'google chrome\' --incognito',
 		'  $ opn unicorn.png'
 	]
+},
+{
+	alias: {
+		h: 'help',
+		v: 'version'
+	}
 });
+
+if (!cli.input.length) cli.showHelp();
 
 cli.flags.app = cli.input.slice(1);
 


### PR DESCRIPTION
Hi @sindresorhus 

some little fixes and additions here

before call `opn` alone exits like that

``` bash
$ opn
/usr/local/homebrew/lib/node_modules/opn-cli/node_modules/opn/index.js:8
        throw new Error('Expected a `target`');
        ^

Error: Expected a `target`
    at module.exports (/usr/local/homebrew/lib/node_modules/opn-cli/node_modules/opn/index.js:8:9)
    at Object.<anonymous> (/usr/local/homebrew/lib/node_modules/opn-cli/cli.js:37:1)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:467:10)
    at startup (node.js:134:18)
    at node.js:961:3
```

With this PR, display the help

``` bash
$ opn

  Usage
    $ opn <file|url> [--no-wait] [-- <app> [args]]

  Options
    --no-wait  Don't wait for the app to exit

  Example
    $ opn http://sindresorhus.com
    $ opn http://sindresorhus.com -- firefox
    $ opn http://sindresorhus.com -- 'google chrome' --incognito
    $ opn unicorn.png
```

Before, `opn --version` shows the opn-cli version

``` bash
$ opn --version
1.0.0
```

With this PR, shows the `opn` module version used

``` bash
$ opn --version
3.0.3
```

Also some aliases added to shows `help` and `version`

``` bash
$ opn -h
$ opn -v
```

Thanks!
