### PR TITLE
Update `opn` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "file-type": "^3.6.0",
     "get-stdin": "^5.0.1",
     "meow": "^3.7.0",
-    "opn": "^4.0.0",
+    "opn": "^5.4.0",
     "temp-write": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
 since last version of xdg-open is needed for it to work on arch linux to open url without explicit app