### PR TITLE
Replace `temp-write` with `tempy`

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,7 +3,7 @@
 const meow = require('meow');
 const open = require('open');
 const getStdin = require('get-stdin');
-const tempWrite = require('temp-write');
+const tempy = require('tempy');
 const fileType = require('file-type');
 
 // eslint-disable-next-line unicorn/string-content
@@ -56,6 +56,6 @@ if (!input && process.stdin.isTTY) {
 		const stdin = await getStdin.buffer();
 		const type = fileType(stdin);
 		const extension = cli.flags.extension || (type && type.ext) || 'txt';
-		await open(tempWrite.sync(stdin, `open.${extension}`), cli.flags);
+		await open(await tempy.write(stdin, {extension}), cli.flags);
 	}
 })();

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"get-stdin": "^7.0.0",
 		"meow": "^6.1.0",
 		"open": "^7.0.3",
-		"temp-write": "^4.0.0"
+		"tempy": "^0.5.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",


### PR DESCRIPTION
Since tempy is more maintained than temp-write, we're replacing it in this PR.