### PR TITLE
Replace `get-stdin` with Node's `streamConsumers.buffer`

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -59,7 +59,7 @@ if (appName) {
 if (input) {
 	await open(input, options);
 } else {
-	const stdin = await streamConsumers.buffer();
+	const stdin = await streamConsumers.buffer(process.stdin);
 	const type = await fileTypeFromBuffer(stdin);
 	const extension = cli.flags.extension ?? type?.ext ?? 'txt';
 	const filePath = await temporaryWrite(stdin, {extension});

--- a/cli.js
+++ b/cli.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import process from 'node:process';
+import * as streamConsumers from 'node:stream/consumers';
 import meow from 'meow';
 import open from 'open';
-import getStdin from 'get-stdin';
 import {temporaryWrite} from 'tempy';
 import {fileTypeFromBuffer} from 'file-type';
 
@@ -59,7 +59,7 @@ if (appName) {
 if (input) {
 	await open(input, options);
 } else {
-	const stdin = await getStdin.buffer();
+	const stdin = await streamConsumers.buffer();
 	const type = await fileTypeFromBuffer(stdin);
 	const extension = cli.flags.extension ?? type?.ext ?? 'txt';
 	const filePath = await temporaryWrite(stdin, {extension});

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
 	],
 	"dependencies": {
 		"file-type": "^18.7.0",
-		"get-stdin": "^9.0.0",
 		"meow": "^12.1.1",
 		"open": "^10.0.0",
 		"tempy": "^3.1.0"

--- a/test.js
+++ b/test.js
@@ -1,7 +1,21 @@
+import {createReadStream} from 'node:fs';
+import path from 'node:path';
 import test from 'ava';
 import {execa} from 'execa';
 
 test('main', async t => {
 	const {stdout} = await execa('./cli.js', ['--version']);
 	t.true(stdout.length > 0);
+});
+
+test('supports opening files from stdin', async t => {
+	const cliPath = path.join(import.meta.dirname, './cli.js');
+
+	const stdinStream = createReadStream(cliPath);
+
+	const subprocess = execa(cliPath, {
+		input: stdinStream,
+	});
+
+	await t.notThrowsAsync(subprocess);
 });

--- a/test.js
+++ b/test.js
@@ -1,5 +1,4 @@
 import {createReadStream} from 'node:fs';
-import path from 'node:path';
 import test from 'ava';
 import {execa} from 'execa';
 
@@ -9,12 +8,8 @@ test('main', async t => {
 });
 
 test('supports opening files from stdin', async t => {
-	const cliPath = path.join(import.meta.dirname, './cli.js');
-
-	const stdinStream = createReadStream(cliPath);
-
-	const subprocess = execa(cliPath, {
-		input: stdinStream,
+	const subprocess = execa('./cli.js', {
+		input: createReadStream('./cli.js'),
 	});
 
 	await t.notThrowsAsync(subprocess);


### PR DESCRIPTION
This pull request removes `get-stdin` in favor of built-in ` streamConsumers.buffer`.

The utility is available since Node 16, and the package targets Node 18+, which makes the change backwards compatible.

From `get-stdin`'s readme:

> You can now accomplish this natively in Node.js using streamConsumers.text() or streamConsumers.buffer():